### PR TITLE
Fix python_requires specifier syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ packages = find:
 install_requires =
     flake8
     typing; python_version<"3.5"
-python_requires = '>=3'
+python_requires = >=3
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The single quotes around this version specifier are not valid syntax for setuptools (the example https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires which this appears copied from was providing Python syntax, whereas in the `.cfg` file variant strings aren't quoted).

Previously, setuptools was warning about this but accepting it, but Python 3.7.5 introduced a version of setuptools (41.2.0) which exits with a fatal error when encountering this syntax.